### PR TITLE
TZUP-527 Add message key for remark duplicate name error

### DIFF
--- a/src/main/java/org/openlmis/buq/errorhandling/GlobalErrorHandling.java
+++ b/src/main/java/org/openlmis/buq/errorhandling/GlobalErrorHandling.java
@@ -44,6 +44,7 @@ public class GlobalErrorHandling extends AbstractErrorHandling {
 
   static {
     CONSTRAINT_MAP.put("unq_source_of_fund_name", MessageKeys.ERROR_SOURCE_OF_FUND_NAME_DUPLICATED);
+    CONSTRAINT_MAP.put("remarks_unique_name", MessageKeys.ERROR_REMARK_NAME_DUPLICATED);
   }
 
   @ExceptionHandler(NotFoundException.class)

--- a/src/main/java/org/openlmis/buq/i18n/MessageKeys.java
+++ b/src/main/java/org/openlmis/buq/i18n/MessageKeys.java
@@ -54,6 +54,9 @@ public abstract class MessageKeys {
           ID, MISMATCH);
   public static final String ERROR_SOURCE_OF_FUND_NAME_DUPLICATED =
           join(ERROR_PREFIX, SOURCE_OF_FUND, NAME, DUPLICATED);
+
+  public static final String ERROR_REMARK_NAME_DUPLICATED =
+          join(ERROR_PREFIX, REMARK, NAME, DUPLICATED);
   public static final String ERROR_REMARK_NOT_FOUND = join(ERROR_PREFIX, REMARK, NOT_FOUND);
   public static final String ERROR_USER_NOT_FOUND = join(ERROR_PREFIX, AUTHENTICATION,
       "userCanNotBeFound");

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -9,6 +9,7 @@ buq.error.sourceOfFund.notFound=Source of fund not found!
 
 # Remarks
 buq.error.remark.notFound=Remark has not been found
+buq.error.remark.name.duplicated=Remark name duplicated.
 
 # Authentication errors
 buq.error.authentication.userCanNotBeFound=User with id {0} can not be found.


### PR DESCRIPTION
This PR targets Ola's request for a more user-friendly message when an error is thrown.