### PR TITLE
TZUP-533: Refactor error handling

### DIFF
--- a/src/main/java/org/openlmis/buq/errorhandling/BottomUpQuantificationErrorHandling.java
+++ b/src/main/java/org/openlmis/buq/errorhandling/BottomUpQuantificationErrorHandling.java
@@ -15,8 +15,8 @@
 
 package org.openlmis.buq.errorhandling;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.openlmis.buq.exception.BindingResultException;
 import org.openlmis.buq.util.Message;
 import org.springframework.http.HttpStatus;
@@ -33,13 +33,15 @@ public class BottomUpQuantificationErrorHandling extends AbstractErrorHandling {
   @ExceptionHandler(BindingResultException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ResponseBody
-  public Map<String, Message.LocalizedMessage> handleBindingResultException(
+  public Message.LocalizedMessage handleBindingRequltException(
           BindingResultException ex) {
-    Map<String, Message.LocalizedMessage> errors = new HashMap<>();
+    List<Message.LocalizedMessage> errors = ex.getErrors()
+            .values()
+            .stream()
+            .map(this::getLocalizedMessage)
+            .collect(Collectors.toList());
 
-    ex.getErrors()
-            .forEach((field, message) -> errors.put(field, getLocalizedMessage(message)));
 
-    return errors;
+    return !errors.isEmpty() ? errors.get(0) : null;
   }
 }

--- a/src/main/java/org/openlmis/buq/errorhandling/BottomUpQuantificationErrorHandling.java
+++ b/src/main/java/org/openlmis/buq/errorhandling/BottomUpQuantificationErrorHandling.java
@@ -33,7 +33,7 @@ public class BottomUpQuantificationErrorHandling extends AbstractErrorHandling {
   @ExceptionHandler(BindingResultException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ResponseBody
-  public Message.LocalizedMessage handleBindingRequltException(
+  public Message.LocalizedMessage handleBindingResultException(
           BindingResultException ex) {
     List<Message.LocalizedMessage> errors = ex.getErrors()
             .values()


### PR DESCRIPTION
Because of the fact, that the alert on the frontend side handles only single record of 
```java
{ messageKey: "...", message: "..." }
```
and it doesn't handle a case where we have multiple errors like:
```java
{
  processingPeriodId: {
   messageKey: "...",
   message: "...",
 },
 name: {
   messageKey: "...",
   message: "...",
 },
}
```
I had to refactor it to return only a single error for now, because there is no direct access to refactor the alert on the frontend side....
I don't feel comfortable with this change, however I don't see any alternative for now.