### PR TITLE
Fix JaVersIntegrationTest by scoping snapshot query to the test instance

### DIFF
--- a/src/integration-test/java/org/openlmis/buq/JaVersIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/buq/JaVersIntegrationTest.java
@@ -77,7 +77,7 @@ public class JaVersIntegrationTest {
 
     // then
     List<CdoSnapshot> snapshots = javers.findSnapshots(
-        QueryBuilder.byClass(SourceOfFund.class).build());
+        QueryBuilder.byInstanceId(sourceOfFund.getId(), SourceOfFund.class).build());
     assertEquals(2, snapshots.size());
 
     LocalDateTime commitTime1 = snapshots.get(0).getCommitMetadata().getCommitDate();


### PR DESCRIPTION
## Summary

Fixes the failing `JaVersIntegrationTest.shouldAlwaysCommitWithUtcTimeZone` integration test, which failed with `expected:<2> but was:<10>`.

## Root cause

The test asserted the number of JaVers snapshots for the entity it commits, but queried them with:

```java
QueryBuilder.byClass(SourceOfFund.class).build()
```

`byClass(...)` returns **every** `SourceOfFund` snapshot in the JaVers store. JaVers snapshots are persisted to JaVers' own tables and are **not** rolled back by `@Transactional`, so snapshots created by other tests (e.g. `AuditLogInitializerIntegrationTest`) and accumulated across runs on a non-clean database were counted too. The test implicitly assumed the store held only the two snapshots it created — a precondition that no longer holds — so `size()` returned 10 instead of 2.

## Fix

Scope the query to the specific instance the test creates (via its random `UUID`):

```java
QueryBuilder.byInstanceId(sourceOfFund.getId(), SourceOfFund.class).build()
```

This is the same pattern already used in `AuditLogInitializerIntegrationTest`. The test now depends only on its own data and is independent of any pre-existing audit snapshots. No new imports are needed, and the timezone assertions (the actual purpose of the test) are unchanged.

## Testing

- One-line change to a single integration test; the fix mirrors an existing, passing test in the same package.
- Not executed locally (requires a running PostgreSQL instance); please rely on CI for the full `integrationTest` run.