### PR TITLE
MW-1471: Activate Prometheus metrics endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ repositories {
 
 dependencies {
     compile "org.springframework.boot:spring-boot-starter-actuator"
+    compile "io.micrometer:micrometer-registry-prometheus"
     compile "org.springframework.boot:spring-boot-starter-data-jpa"
     compile "org.springframework.boot:spring-boot-starter-data-rest"
     compile "org.springframework.boot:spring-boot-starter-web"

--- a/src/main/java/org/openlmis/buq/security/ResourceServerSecurityConfiguration.java
+++ b/src/main/java/org/openlmis/buq/security/ResourceServerSecurityConfiguration.java
@@ -86,6 +86,7 @@ public class ResourceServerSecurityConfiguration implements ResourceServerConfig
         .authorizeRequests()
         .antMatchers(
             "/actuator/health",
+            "/actuator/prometheus",
             "/buq",
             "/webjars/**",
             "/buq/webjars/**",

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,7 +23,8 @@ spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialec
 
 management.endpoints.enabled-by-default=false
 management.endpoint.health.enabled=true
-management.endpoints.web.exposure.include=health
+management.endpoint.prometheus.enabled=true
+management.endpoints.web.exposure.include=health,prometheus
 
 server.compression.enabled=true
 server.compression.mime-types=application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css


### PR DESCRIPTION
Activates the Prometheus (Micrometer) actuator endpoint so JVM/HTTP metrics can be scraped by a Grafana Alloy agent (OpenLMIS Malawi monitoring). build.gradle adds micrometer-registry-prometheus (actuator starter already on master); application.properties enables+exposes the prometheus endpoint (management.endpoint.prometheus.enabled=true; master sets enabled-by-default=false); ResourceServerSecurityConfiguration permits /actuator/prometheus (like the existing /actuator/health). Only reachable on the internal network in the Malawi deployment. Verified: builds, boots, GET /actuator/prometheus returns 200 (84 series). Companion hotfix branch rel-1.0.2-hotfix.1 carries the same activation on the deployed 1.0.2 line.